### PR TITLE
Fixed Brocken URL in Documentation

### DIFF
--- a/content/1.getting-started/1.introduction.md
+++ b/content/1.getting-started/1.introduction.md
@@ -535,5 +535,5 @@ This project is open source and available under the [MIT license](https://openso
 ::alert{type="info" icon="ph:info"}
 We welcome contributions from the community! Whether it's fixing typos, improving explanations, adding new examples, or translating content—every contribution helps make this resource better for everyone.
 
-Visit our [GitHub repository](https://github.com/username/from-docker-to-kubernetes) to learn how you can contribute.
+Visit our [GitHub repository](https://github.com/NotHarshhaa/from-docker-to-kubernetes) to learn how you can contribute.
 ::


### PR DESCRIPTION
The previous link returned a 404. Updated to the correct working URL.
